### PR TITLE
CM-5 Add a network service as the api client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,11 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_OSX_ARCHITECTURES x86_64)
 
-add_executable(rxcpp main.cpp)
+# Set the backend url, if you use CLion
+# go to CLion > Preferences > Build, Execution, Deployment > CMake
+# and add the following option
+# -DBACKEND_URI="\"https://your-backend-url\""
+add_compile_definitions(BACKEND_URI=${BACKEND_URI})
+
+add_executable(rxcpp main.cpp Services/INetworkService.h Services/NetworkService.cpp Services/NetworkService.h)
 target_link_libraries(rxcpp ${CONAN_LIBS})

--- a/Services/INetworkService.h
+++ b/Services/INetworkService.h
@@ -1,0 +1,18 @@
+//
+// Created by HANYOUNG PARK on 5/13/22.
+//
+
+#ifndef RXCPP_INETWORKSERVICE_H
+#define RXCPP_INETWORKSERVICE_H
+
+#include <string>
+
+namespace HanyoungparkClient::NetworkService{
+    class INetworkService {
+    public:
+        virtual ~INetworkService() = default;
+        virtual int getStock(const std::string& symbol) const = 0;
+    };
+} // NetworkService::HanyoungparkClient
+
+#endif //RXCPP_INETWORKSERVICE_H

--- a/Services/NetworkService.cpp
+++ b/Services/NetworkService.cpp
@@ -1,0 +1,49 @@
+//
+// Created by HANYOUNG PARK on 5/13/22.
+//
+
+#include "NetworkService.h"
+#include <iostream>
+#include <cpprest/http_client.h>
+#include <cpprest/filestream.h>
+#include <cpprest/http_listener.h>              // HTTP server
+#include <cpprest/json.h>                       // JSON library
+#include <cpprest/uri.h>                        // URI library
+#include <cpprest/ws_client.h>                  // WebSocket client
+#include <cpprest/containerstream.h>            // Async streams backed by STL containers
+#include <cpprest/interopstream.h>              // Bridges for integrating Async streams with STL and WinRT streams
+#include <cpprest/rawptrstream.h>               // Async streams backed by raw pointer to memory
+#include <cpprest/producerconsumerstream.h>     // Async streams for producer consumer scenarios
+
+//using namespace std;
+using namespace utility;                    // Common utilities like string conversions
+using namespace web;                        // Common features like URIs.
+using namespace web::http;                  // Common HTTP functionality
+using namespace web::http::client;          // HTTP client features
+using namespace concurrency::streams;       // Asynchronous streams
+
+namespace HanyoungparkClient::NetworkService {
+    NetworkService::NetworkService() {
+    }
+
+    NetworkService::~NetworkService() {
+    }
+
+    int NetworkService::getStock(const std::string& symbol) const {
+        double price = 0.f;
+        auto request = http_client(U(BACKEND_URI))
+                .request(methods::GET, uri_builder(U("stocks/KRW")).to_string())
+                .then([](const http_response& response){
+                    return response.extract_json();
+                })
+                .then([&price](json::value jsonObject){
+                    price = jsonObject[U("price")].as_double();
+                });
+        try {
+            request.wait();
+        } catch (const std::exception& ex) {
+            std::cout << ex.what() << std::endl;
+        }
+        return price;
+    }
+} // NetworkService::NetworkService

--- a/Services/NetworkService.h
+++ b/Services/NetworkService.h
@@ -1,0 +1,20 @@
+//
+// Created by HANYOUNG PARK on 5/13/22.
+//
+
+#ifndef RXCPP_NETWORKSERVICE_H
+#define RXCPP_NETWORKSERVICE_H
+
+#include "INetworkService.h"
+
+namespace HanyoungparkClient::NetworkService {
+    class NetworkService: public INetworkService {
+    public:
+        NetworkService();
+        ~NetworkService() override;
+
+        [[nodiscard]] int getStock(const std::string& symbol) const override;
+    };
+} // NetworkService::NetworkService
+
+#endif //RXCPP_NETWORKSERVICE_H

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 ftxui/2.0.0
-zlib/1.2.11
+cpprestsdk/2.10.18
 
 [generators]
 cmake

--- a/main.cpp
+++ b/main.cpp
@@ -1,29 +1,25 @@
+#include <iostream>
+
 #include <ftxui/dom/elements.hpp>
 #include <ftxui/screen/screen.hpp>
-#include "ftxui/dom/node.hpp"
+#include <ftxui/dom/node.hpp>
+
+#include "Services/NetworkService.h"
+
+using namespace HanyoungparkClient::NetworkService;
 
 int main() {
     using namespace ftxui;
-    auto document =
-        hbox({
-            vbox({
-                text("Line 1"),
-                text("Line 2"),
-                text("Line 3"),
-                }) | border,
-            vbox({
-                text("Line 4"),
-                text("Line 5"),
-                text("Line 6"),
-            }) | border,
-            vbox({
-                text("Line 7"),
-                text("Line 8"),
-                text("Line 9"),
-            }) | border,
-        });
+
+    // NetworkService Test
+    std::unique_ptr<INetworkService> pNetworkService(new NetworkService());
+    auto document = hbox({
+        vbox({text("Stock Price")}) | border,
+        vbox({text(std::to_string(pNetworkService->getStock("USD")))}) | border,
+    });
     auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
     Render(screen, document);
     screen.Print();
+
     return 0;
 }


### PR DESCRIPTION
This app utilizes the `cpprestsdk` from Microsoft to communicate the Rest API.
This document is very helpful to use cpprestsdk: http://www.atakansarioglu.com/easy-quick-start-cplusplus-rest-client-example-cpprest-tutorial/
To test this library, I wrote a simple API using the spring-boot `/stock/{symbol}`